### PR TITLE
[Eddy] NetworkManager의 네트워크 요청 실행 로직을 API Requestable 안으로 이동

### DIFF
--- a/SideDishApp/SideDishApp.xcodeproj/project.pbxproj
+++ b/SideDishApp/SideDishApp.xcodeproj/project.pbxproj
@@ -28,7 +28,7 @@
 		B7F90B46280FD69A0067E4FE /* mockProductDetailData.json in Resources */ = {isa = PBXBuildFile; fileRef = B7F90B3E280FCC340067E4FE /* mockProductDetailData.json */; };
 		B7F90B4C280FE10C0067E4FE /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F90B4B280FE10C0067E4FE /* NetworkManager.swift */; };
 		B7F90B4E280FE1940067E4FE /* SystemLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F90B4D280FE1940067E4FE /* SystemLog.swift */; };
-		B7F90B50280FE29C0067E4FE /* NetworkManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F90B4F280FE29B0067E4FE /* NetworkManagerTests.swift */; };
+		B7F90B50280FE29C0067E4FE /* APIRequestableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F90B4F280FE29B0067E4FE /* APIRequestableTests.swift */; };
 		B7F90B62281006F00067E4FE /* 1155_ZIP_P_0081_T.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B7F90B61281006F00067E4FE /* 1155_ZIP_P_0081_T.jpg */; };
 		B7F90B6E2810081D0067E4FE /* ProductSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F90B23280E7C2A0067E4FE /* ProductSummary.swift */; };
 		B7F90B70281008200067E4FE /* ProductDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F90B42280FCD710067E4FE /* ProductDetail.swift */; };
@@ -118,7 +118,7 @@
 		B7F90B44280FD65D0067E4FE /* ProductDetailDecodingTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailDecodingTest.swift; sourceTree = "<group>"; };
 		B7F90B4B280FE10C0067E4FE /* NetworkManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		B7F90B4D280FE1940067E4FE /* SystemLog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemLog.swift; sourceTree = "<group>"; };
-		B7F90B4F280FE29B0067E4FE /* NetworkManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkManagerTests.swift; sourceTree = "<group>"; };
+		B7F90B4F280FE29B0067E4FE /* APIRequestableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIRequestableTests.swift; sourceTree = "<group>"; };
 		B7F90B61281006F00067E4FE /* 1155_ZIP_P_0081_T.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; name = 1155_ZIP_P_0081_T.jpg; path = resources/1155_ZIP_P_0081_T.jpg; sourceTree = "<group>"; };
 		B7F90B8B2810523A0067E4FE /* MainCollectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCollectionViewModel.swift; sourceTree = "<group>"; };
 		B7F90B8D2810561A0067E4FE /* Obseverable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Obseverable.swift; sourceTree = "<group>"; };
@@ -289,7 +289,7 @@
 			children = (
 				B7F90B912810723E0067E4FE /* MainCollectionViewModelTests.swift */,
 				BC737208281A8D6E0082C5DB /* ProductDetailViewModelTests.swift */,
-				B7F90B4F280FE29B0067E4FE /* NetworkManagerTests.swift */,
+				B7F90B4F280FE29B0067E4FE /* APIRequestableTests.swift */,
 				B7F90B44280FD65D0067E4FE /* ProductDetailDecodingTest.swift */,
 				B7F90B2B280E86200067E4FE /* ProductDecodingTests.swift */,
 				B7F90B61281006F00067E4FE /* 1155_ZIP_P_0081_T.jpg */,
@@ -716,7 +716,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B7F90B50280FE29C0067E4FE /* NetworkManagerTests.swift in Sources */,
+				B7F90B50280FE29C0067E4FE /* APIRequestableTests.swift in Sources */,
 				BC7371FB281938FF0082C5DB /* ImageRequest.swift in Sources */,
 				B7F90B772810086E0067E4FE /* NetworkError.swift in Sources */,
 				B7F90B71281008220067E4FE /* Category.swift in Sources */,

--- a/SideDishApp/SideDishApp.xcodeproj/project.pbxproj
+++ b/SideDishApp/SideDishApp.xcodeproj/project.pbxproj
@@ -42,7 +42,7 @@
 		B7F90B8C2810523A0067E4FE /* MainCollectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F90B8B2810523A0067E4FE /* MainCollectionViewModel.swift */; };
 		B7F90B8E2810561A0067E4FE /* Obseverable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F90B8D2810561A0067E4FE /* Obseverable.swift */; };
 		B7F90B90281059870067E4FE /* ProductCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F90B8F281059870067E4FE /* ProductCellViewModel.swift */; };
-		B7F90B922810723E0067E4FE /* ProductCollectionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F90B912810723E0067E4FE /* ProductCollectionViewModelTests.swift */; };
+		B7F90B922810723E0067E4FE /* MainCollectionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F90B912810723E0067E4FE /* MainCollectionViewModelTests.swift */; };
 		B7F90B932810725C0067E4FE /* MainCollectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F90B8B2810523A0067E4FE /* MainCollectionViewModel.swift */; };
 		B7F90B942810725E0067E4FE /* ProductCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F90B8F281059870067E4FE /* ProductCellViewModel.swift */; };
 		B7F90B95281076BE0067E4FE /* Obseverable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F90B8D2810561A0067E4FE /* Obseverable.swift */; };
@@ -66,6 +66,7 @@
 		BC7371FE281939120082C5DB /* ProductDetailRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7371FC281939120082C5DB /* ProductDetailRequest.swift */; };
 		BC737200281939370082C5DB /* CategoryRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7371FF281939370082C5DB /* CategoryRequest.swift */; };
 		BC737201281939370082C5DB /* CategoryRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7371FF281939370082C5DB /* CategoryRequest.swift */; };
+		BC737209281A8D6E0082C5DB /* ProductDetailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC737208281A8D6E0082C5DB /* ProductDetailViewModelTests.swift */; };
 		BCFE4836280D5AE100F23DCE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFE4835280D5AE100F23DCE /* AppDelegate.swift */; };
 		BCFE4838280D5AE100F23DCE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFE4837280D5AE100F23DCE /* SceneDelegate.swift */; };
 		BCFE483A280D5AE100F23DCE /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFE4839280D5AE100F23DCE /* MainViewController.swift */; };
@@ -122,7 +123,7 @@
 		B7F90B8B2810523A0067E4FE /* MainCollectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCollectionViewModel.swift; sourceTree = "<group>"; };
 		B7F90B8D2810561A0067E4FE /* Obseverable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Obseverable.swift; sourceTree = "<group>"; };
 		B7F90B8F281059870067E4FE /* ProductCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCellViewModel.swift; sourceTree = "<group>"; };
-		B7F90B912810723E0067E4FE /* ProductCollectionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCollectionViewModelTests.swift; sourceTree = "<group>"; };
+		B7F90B912810723E0067E4FE /* MainCollectionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCollectionViewModelTests.swift; sourceTree = "<group>"; };
 		B7F90B97281128DB0067E4FE /* .swiftlint.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		B7F90B9928114F470067E4FE /* CurrencyFormattable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyFormattable.swift; sourceTree = "<group>"; };
 		B7F90BA6281246300067E4FE /* MainCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -135,6 +136,7 @@
 		BC7371F9281938FF0082C5DB /* ImageRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRequest.swift; sourceTree = "<group>"; };
 		BC7371FC281939120082C5DB /* ProductDetailRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailRequest.swift; sourceTree = "<group>"; };
 		BC7371FF281939370082C5DB /* CategoryRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRequest.swift; sourceTree = "<group>"; };
+		BC737208281A8D6E0082C5DB /* ProductDetailViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailViewModelTests.swift; sourceTree = "<group>"; };
 		BCFE4832280D5AE100F23DCE /* SideDishApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SideDishApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCFE4835280D5AE100F23DCE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BCFE4837280D5AE100F23DCE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -285,7 +287,8 @@
 		BCFE484B280D5AE200F23DCE /* SideDishAppTests */ = {
 			isa = PBXGroup;
 			children = (
-				B7F90B912810723E0067E4FE /* ProductCollectionViewModelTests.swift */,
+				B7F90B912810723E0067E4FE /* MainCollectionViewModelTests.swift */,
+				BC737208281A8D6E0082C5DB /* ProductDetailViewModelTests.swift */,
 				B7F90B4F280FE29B0067E4FE /* NetworkManagerTests.swift */,
 				B7F90B44280FD65D0067E4FE /* ProductDetailDecodingTest.swift */,
 				B7F90B2B280E86200067E4FE /* ProductDecodingTests.swift */,
@@ -722,7 +725,7 @@
 				BC7371F8281938CE0082C5DB /* APIRequestable.swift in Sources */,
 				B7F90B75281008290067E4FE /* Delivery.swift in Sources */,
 				B7F90B7E2810094B0067E4FE /* SystemLog.swift in Sources */,
-				B7F90B922810723E0067E4FE /* ProductCollectionViewModelTests.swift in Sources */,
+				B7F90B922810723E0067E4FE /* MainCollectionViewModelTests.swift in Sources */,
 				BCFE484D280D5AE200F23DCE /* SideDishAppTests.swift in Sources */,
 				B7F90B932810725C0067E4FE /* MainCollectionViewModel.swift in Sources */,
 				B7F90B9B2811AA200067E4FE /* CurrencyFormattable.swift in Sources */,
@@ -732,6 +735,7 @@
 				B7F90B942810725E0067E4FE /* ProductCellViewModel.swift in Sources */,
 				BC7371EF2817F08A0082C5DB /* OrderViewModel.swift in Sources */,
 				BC7371EC2817F0210082C5DB /* ProductDetailViewModel.swift in Sources */,
+				BC737209281A8D6E0082C5DB /* ProductDetailViewModelTests.swift in Sources */,
 				B7F90B70281008200067E4FE /* ProductDetail.swift in Sources */,
 				B7F90B2C280E86200067E4FE /* ProductDecodingTests.swift in Sources */,
 				B7F90B762810086C0067E4FE /* NetworkManager.swift in Sources */,

--- a/SideDishApp/SideDishApp/Model/Networking/APIRequestable.swift
+++ b/SideDishApp/SideDishApp/Model/Networking/APIRequestable.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Alamofire
+import UIKit
 
 protocol APIRequestable {
     associatedtype Response
@@ -24,9 +25,37 @@ extension APIRequestable {
     // Header, queryItem이 없을 경우 구현하지 않아도 됨
     var headers: [String: String] { [:] }
     var queryItems: [String: String] { [:] }
+
+    // Request 생성 로직은 모든 구체 타입에서 동일하므로 default로 구현
+    func buildRequest() -> DataRequest {
+        return AF.request(self.url,
+                          method: self.method,
+                          parameters: self.queryItems,
+                          headers: HTTPHeaders(self.headers)
+        )
+    }
+}
+
+extension APIRequestable {
+    // execute 로직은 현재 모든 구체 타입에서 동일하므로 default로 구현
+    func execute(completion: @escaping (Response?) -> Void) {
+        self.buildRequest()
+            .validate()
+            .responseData { response in
+                switch response.result {
+                case .success(let data):
+                    return completion(decode(data))
+                case .failure(let error):
+                    SystemLog.fault(error.localizedDescription)
+                    return completion(nil)
+                }
+            }
+    }
 }
 
 extension APIRequestable where Response: Decodable {
+    // Decoding 로직은 Response type이 Decodable한지, 그냥 Binary Data인지에 따라 달라짐.
+    // type constraint를 사용해서 default를 다르게 구현
     func decode(_ data: Data) -> Response? {
         do {
             return try JSONDecoder().decode(Response.self, from: data)

--- a/SideDishApp/SideDishApp/Model/Networking/APIRequestable.swift
+++ b/SideDishApp/SideDishApp/Model/Networking/APIRequestable.swift
@@ -37,6 +37,12 @@ extension APIRequestable where Response: Decodable {
     }
 }
 
+extension APIRequestable where Response == Data {
+    func decode(_ data: Data) -> Response? {
+        return data
+    }
+}
+
 extension URLComponents {
     static let onbanBaseURLComponents: Self = {
         var components = URLComponents()

--- a/SideDishApp/SideDishApp/Model/Networking/CategoryRequest.swift
+++ b/SideDishApp/SideDishApp/Model/Networking/CategoryRequest.swift
@@ -9,6 +9,7 @@ import Foundation
 import Alamofire
 
 struct CategoryRequest: APIRequestable {
+
     typealias Response = CategoryResponse
     var url: URL
     var method: HTTPMethod = .get

--- a/SideDishApp/SideDishApp/Model/Networking/ImageRequest.swift
+++ b/SideDishApp/SideDishApp/Model/Networking/ImageRequest.swift
@@ -30,8 +30,4 @@ struct ImageRequest: APIRequestable {
         guard let url = components.url else { return nil }
         self.url = url
     }
-
-    func decode(_ data: Data) -> Response? {
-        return data
-    }
 }

--- a/SideDishApp/SideDishApp/ViewModel/MainCollectionViewModel.swift
+++ b/SideDishApp/SideDishApp/ViewModel/MainCollectionViewModel.swift
@@ -55,11 +55,11 @@ struct MainCollectionViewModel {
 
     private func fetchCategories(of type: CategoryType) {
 
-        guard let request = CategoryRequest(from: type) else {
+        guard let categoryRequest = CategoryRequest(from: type) else {
             return
         }
 
-        networkManager.request(request) { categoryResponse in
+        categoryRequest.execute { categoryResponse in
             guard let productCellVMs = categoryResponse?.body.compactMap({ productSummary in
                 ProductCellViewModel(product: productSummary)
             }) else { return }
@@ -74,11 +74,11 @@ struct MainCollectionViewModel {
             return completion(image)
         }
 
-        guard let request = ImageRequest(url: url) else {
+        guard let imageRequest = ImageRequest(url: url) else {
             return
         }
 
-        networkManager.request(request) { data in
+        imageRequest.execute { data in
             guard let data = data as? NSData else {
                 return completion(nil)
             }

--- a/SideDishApp/SideDishApp/ViewModel/ProductDetailViewModel.swift
+++ b/SideDishApp/SideDishApp/ViewModel/ProductDetailViewModel.swift
@@ -14,7 +14,6 @@ struct ProductDetailViewModel {
     public let point = Observable<Money<KRW>>(Money<KRW>(""))
     public let detailSectionURL = Observable<[URL]>([])
 
-    let networkManager = NetworkManager()
     let hash: String
 
     init(from hash: String) {
@@ -22,10 +21,9 @@ struct ProductDetailViewModel {
     }
 
     func fetchDetail() {
-        guard let request = ProductDetailRequest(from: hash) else { return }
+        guard let productRequest = ProductDetailRequest(from: hash) else { return }
 
-        networkManager.request(request) {
-            productDetailResponse in
+        productRequest.execute { productDetailResponse in
             guard let productDetail = productDetailResponse?.data else { return }
 
             thumbImagesURL.value = productDetail.thumbImagesURL
@@ -34,6 +32,5 @@ struct ProductDetailViewModel {
             point.value = productDetail.point
             detailSectionURL.value = productDetail.detailSectionURL
         }
-
     }
 }

--- a/SideDishApp/SideDishAppTests/APIRequestableTests.swift
+++ b/SideDishApp/SideDishAppTests/APIRequestableTests.swift
@@ -8,9 +8,7 @@
 import XCTest
 @testable import SideDishApp
 
-class NetworkManagerTests: XCTestCase {
-
-    let networkManager = NetworkManager()
+class APIRequestableTests: XCTestCase {
 
     func testExample() throws {
         let two = 2
@@ -21,14 +19,14 @@ class NetworkManagerTests: XCTestCase {
         let promise = XCTestExpectation(description: "Fetch product detail success")
 
         let testHash = "HBDEF"
-        let request = ProductDetailRequest(from: testHash)
-        XCTAssertNotNil(request)
+        let productDetailRequest = ProductDetailRequest(from: testHash)
+        XCTAssertNotNil(productDetailRequest)
 
-        networkManager.request(request!) { data in
+        productDetailRequest!.execute(completion: { data in
             XCTAssertNotNil(data)
             XCTAssertEqual(data?.hash, testHash)
             promise.fulfill()
-        }
+        })
 
         wait(for: [promise], timeout: 1)
     }
@@ -45,10 +43,10 @@ class NetworkManagerTests: XCTestCase {
             return XCTFail("Could not load test Image from bundle")
         }
 
-        let request = ImageRequest(fileName: fileName, fileExtension: fileExtension)
-        XCTAssertNotNil(request)
+        let imageRequest = ImageRequest(fileName: fileName, fileExtension: fileExtension)
+        XCTAssertNotNil(imageRequest)
 
-        networkManager.request(request!) { data in
+        imageRequest!.execute { data in
             XCTAssertEqual(data, localImageData)
             promise.fulfill()
         }
@@ -60,10 +58,10 @@ class NetworkManagerTests: XCTestCase {
     func testFetchCategory() throws {
         let promise = XCTestExpectation(description: "Fetch Category success")
 
-        let request = CategoryRequest(from: .main)
-        XCTAssertNotNil(request)
+        let categoryRequest = CategoryRequest(from: .main)
+        XCTAssertNotNil(categoryRequest)
 
-        networkManager.request(request!) { data in
+        categoryRequest!.execute { data in
             XCTAssertNotNil(data)
             promise.fulfill()
         }

--- a/SideDishApp/SideDishAppTests/MainCollectionViewModelTests.swift
+++ b/SideDishApp/SideDishAppTests/MainCollectionViewModelTests.swift
@@ -7,19 +7,19 @@
 
 import XCTest
 
-class ProductCollectionViewModelTests: XCTestCase {
+class MainCollectionViewModelTests: XCTestCase {
 
-    let productCollectionViewModel = ProductCollectionViewModel()
+    let mainCollectionViewModel = MainCollectionViewModel()
 
     func testFetch() throws {
         let promise = XCTestExpectation(description: "Section View Model fetched")
 
-        productCollectionViewModel.categoryVMs[.main]?.bind { sectionVM in
+        mainCollectionViewModel.categoryVMs[.main]?.bind { sectionVM in
             XCTAssertTrue(sectionVM?.productVMs.count == 8)
             promise.fulfill()
         }
 
-        productCollectionViewModel.fetchAllCategories()
+        mainCollectionViewModel.fetchAllCategories()
 
         wait(for: [promise], timeout: 1)
     }

--- a/SideDishApp/SideDishAppTests/ProductDetailViewModelTests.swift
+++ b/SideDishApp/SideDishAppTests/ProductDetailViewModelTests.swift
@@ -1,0 +1,27 @@
+//
+//  ProductDetailViewModelTests.swift
+//  SideDishAppTests
+//
+//  Created by Bumgeun Song on 2022/04/28.
+//
+
+import XCTest
+
+class ProductDetailViewModelTests: XCTestCase {
+
+    func testFetch() throws {
+        let testHash = "HBDEF"
+        let productDetailViewModel = ProductDetailViewModel(from: testHash)
+
+        let promise = XCTestExpectation(description: "Product Detail Point data fetched")
+
+        productDetailViewModel.point.bind { point in
+            XCTAssertEqual(point?.value, Decimal(126))
+            promise.fulfill()
+        }
+
+        productDetailViewModel.fetchDetail()
+
+        wait(for: [promise], timeout: 1)
+    }
+}


### PR DESCRIPTION
- [ ] API Requestable 안에 execute()를 구현해서 네트워크 요청을 실행하도록 만들어줌
- [ ] NetworkManager 삭제
- [ ] API Requestable 테스트 케이스 추가